### PR TITLE
Recommend calling resetAll() on tearDown()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ class MyTest extends WebTestCase
 
         // ...
         self::$client->request(...);
+    }
 
-        // To make sure we dont use affect other tests
+    protected function tearDown(): void
+    {
+        // To make sure we don't affect other tests
         ServiceMock::resetAll();
         // You can include the RestoreServiceContainer trait to automatically reset services
     }


### PR DESCRIPTION
The example in the README calls `ServiceMock::resetAll()` at the end of the test. However, this is problematic because `ServiceMock::resetAll()` would only be called if the test does not fail.

This PR proposes to move the `ServiceMock::resetAll()` call into a `tearDown()` method instead. An alternative approach could be to wrap the call into a `try {…} finally {…}` construct.