### PR TITLE
Make mocked services non-lazy

### DIFF
--- a/src/DependencyInjection/CompilerPass/ProxyServiceWithMockPass.php
+++ b/src/DependencyInjection/CompilerPass/ProxyServiceWithMockPass.php
@@ -45,7 +45,7 @@ class ProxyServiceWithMockPass implements CompilerPassInterface
             $proxy = $factory->createProxy($definition->getClass(), $initializer);
             $definition->setClass($proxyClass = get_class($proxy));
             $definition->setPublic(true);
-            $definition->setLazy(true);
+            $definition->setLazy(false);
 
             if (null !== $definition->getFactory()) {
                 $factoryMethod = $definition->getFactory();


### PR DESCRIPTION
This will avoid problems like

> A method by name setProxyInitializer already exists in this class.


This will fix #24 and do what #14 intended to do. 