### PR TITLE
Add SkipDestructor

### DIFF
--- a/src/DependencyInjection/CompilerPass/ProxyServiceWithMockPass.php
+++ b/src/DependencyInjection/CompilerPass/ProxyServiceWithMockPass.php
@@ -42,7 +42,7 @@ class ProxyServiceWithMockPass implements CompilerPassInterface
                 return true;
             };
 
-            $proxy = $factory->createProxy($definition->getClass(), $initializer);
+            $proxy = $factory->createProxy($definition->getClass(), $initializer, ['skipDestructor' => true]);
             $definition->setClass($proxyClass = get_class($proxy));
             $definition->setPublic(true);
             $definition->setLazy(false);

--- a/tests/Functional/config.yml
+++ b/tests/Functional/config.yml
@@ -2,10 +2,14 @@ happyr_service_mocking:
     services:
         - 'Happyr\ServiceMocking\Tests\Resource\ExampleService'
         - 'Happyr\ServiceMocking\Tests\Resource\ServiceWithFactory'
+        - 'Happyr\ServiceMocking\Tests\Resource\ServiceWithDestructor'
 
 services:
 
     Happyr\ServiceMocking\Tests\Resource\ExampleService:
+        public: true
+
+    Happyr\ServiceMocking\Tests\Resource\ServiceWithDestructor:
         public: true
 
     Happyr\ServiceMocking\Tests\Resource\StatefulService:

--- a/tests/Resource/ServiceWithDestructor.php
+++ b/tests/Resource/ServiceWithDestructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happyr\ServiceMocking\Tests\Resource;
+
+class ServiceWithDestructor
+{
+    public function __destruct()
+    {
+    }
+}


### PR DESCRIPTION
This change adds `SkipDestructor` step to the proxy generation (see failing test in separate commit) which replaces the `__destruct()` with a dummy when the proxy is not initialized.

See also https://github.com/symfony/symfony/blob/6.2/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php